### PR TITLE
[Feat] getActor 메서드 추가 및 SecurityConfig 권한 규칙 정리

### DIFF
--- a/src/main/java/com/back/domain/member/member/controller/ApiV1MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/ApiV1MemberController.java
@@ -7,6 +7,7 @@ import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.domain.member.member.service.MemberService;
 import com.back.global.exception.ServiceException;
+import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
 import com.back.global.security.SecurityUser;
 import jakarta.validation.Valid;
@@ -26,6 +27,7 @@ public class ApiV1MemberController {
 
     private final MemberRepository memberRepository;
     private final MemberService memberService;
+    private final Rq rq;
 
     @GetMapping("/check-nickname")
     @Transactional(readOnly = true)
@@ -46,12 +48,11 @@ public class ApiV1MemberController {
 
     @GetMapping("/me")
     @Transactional(readOnly = true)
-    public RsData<MemberMeResponse> me(@AuthenticationPrincipal SecurityUser user) {
-        if (user == null) {
-            throw new ServiceException("401-1", "로그인 후 이용해주세요.");
-        }
+    public RsData<MemberMeResponse> me() {
+        Member actor = rq.getActor();
+        if (actor == null) throw new ServiceException("401-1", "로그인 후 이용해주세요.");
 
-        Member member = memberRepository.findById(user.getId())
+        Member member = memberRepository.findById(actor.getId())
                 .orElseThrow(() -> new ServiceException("404-1", "회원이 존재하지 않습니다."));
 
         return new RsData<>("200-1", "내 정보 조회 성공", new MemberMeResponse(member));
@@ -60,14 +61,12 @@ public class ApiV1MemberController {
     @PutMapping("/me/password")
     @Transactional
     public RsData<Void> changePassword(
-            @AuthenticationPrincipal SecurityUser user,
             @Valid @RequestBody MemberPasswordChangeRequest req
     ) {
-        if (user == null) {
-            throw new ServiceException("401-1", "로그인 후 이용해주세요.");
-        }
+        Member actor = rq.getActor();
+        if (actor == null) throw new ServiceException("401-1", "로그인 후 이용해주세요.");
 
-        memberService.changePassword(user.getId(), req.oldPassword(), req.newPassword());
+        memberService.changePassword(actor.getId(), req.oldPassword(), req.newPassword());
 
         return new RsData<>("200-1", "비밀번호 변경 성공", null);
     }

--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -36,6 +36,12 @@ public class Member extends BaseEntity {
     @Column(unique = true, length = 30, nullable = false)
     private String nickname;
 
+    @CreatedDate
+    private LocalDateTime createDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifyDate;
+
     @OneToMany(mappedBy = "member", fetch = LAZY, cascade = {PERSIST, REMOVE}, orphanRemoval = true)
     private List<MemberGame> library = new ArrayList<>();
 

--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -36,12 +36,6 @@ public class Member extends BaseEntity {
     @Column(unique = true, length = 30, nullable = false)
     private String nickname;
 
-    @CreatedDate
-    private LocalDateTime createDate;
-
-    @LastModifiedDate
-    private LocalDateTime modifyDate;
-
     @OneToMany(mappedBy = "member", fetch = LAZY, cascade = {PERSIST, REMOVE}, orphanRemoval = true)
     private List<MemberGame> library = new ArrayList<>();
 
@@ -50,6 +44,12 @@ public class Member extends BaseEntity {
         this.password = password;
         this.nickname = nickname;
         this.apiKey = UUID.randomUUID().toString();
+    }
+
+    public Member(int id, String email, String nickname) {
+        setId(id);
+        this.email = email;
+        this.nickname = nickname;
     }
 
     public void changePassword(String encodedPassword) {

--- a/src/main/java/com/back/global/rq/Rq.java
+++ b/src/main/java/com/back/global/rq/Rq.java
@@ -1,9 +1,13 @@
 package com.back.global.rq;
 
+import com.back.domain.member.member.entity.Member;
+import com.back.global.security.SecurityUser;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
@@ -15,17 +19,40 @@ public class Rq {
     private final HttpServletRequest req;
     private final HttpServletResponse resp;
 
+    public Member getActor() {
+        return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+                .map(Authentication::getPrincipal)
+                .filter(principal -> principal instanceof SecurityUser)
+                .map(principal -> (SecurityUser) principal)
+                .map(securityUser -> new Member(
+                        securityUser.getId(),
+                        securityUser.getEmail(),
+                        securityUser.getNickname()
+                ))
+                .orElse(null);
+    }
+
     public String getHeader(String name, String defaultValue) {
         return Optional.ofNullable(req.getHeader(name))
                 .filter(v -> !v.isBlank())
                 .orElse(defaultValue);
     }
 
+    public void setHeader(String name, String value) {
+        if (value == null) value = "";
+
+        if (value.isBlank()) {
+            req.removeAttribute(name);
+        } else {
+            resp.setHeader(name, value);
+        }
+    }
+
     public String getCookieValue(String name, String defaultValue) {
         return Optional.ofNullable(req.getCookies())
                 .flatMap(cookies ->
                         Arrays.stream(cookies)
-                                .filter(c -> c.getName().equals(name))
+                                .filter(cookie -> cookie.getName().equals(name))
                                 .map(Cookie::getValue)
                                 .filter(v -> !v.isBlank())
                                 .findFirst()
@@ -39,14 +66,17 @@ public class Rq {
         Cookie cookie = new Cookie(name, value);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
+        cookie.setDomain("localhost");
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "Strict");
 
-        cookie.setSecure(false);
-        cookie.setMaxAge(value.isBlank() ? 0 : 60 * 60 * 24 * 365);
+        if (value.isBlank()) cookie.setMaxAge(0);
+        else cookie.setMaxAge(60 * 60 * 24 * 365);
 
         resp.addCookie(cookie);
     }
 
     public void deleteCookie(String name) {
-        setCookie(name, "");
+        setCookie(name, null);
     }
 }

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -25,7 +25,9 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
         http
+                // 기본 보안 설정
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(Customizer.withDefaults())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(STATELESS))
@@ -55,28 +57,63 @@ public class SecurityConfig {
                         })
                 );
 
-        // =========================
-        // ✅ 정상 코드(최종): /api/** 는 로그인 필요
-        // =========================
-        // http.authorizeHttpRequests(auth -> auth
-        //         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-        //         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-        //         .requestMatchers("/h2-console/**").permitAll()
-        //         .requestMatchers("/api/v1/auth/**").permitAll()
-        //         .requestMatchers(HttpMethod.GET, "/api/v1/members/check-nickname").permitAll()
-        //         .requestMatchers("/api/**").authenticated()
-        //         .anyRequest().permitAll()
-        // );
+        // ==========================================
+        // ✅ 정상 코드(권한 정책 적용)
+        // - 조회(GET)는 공개
+        // - 쓰기/수정/삭제(POST/PUT/DELETE)는 로그인 필요
+        // ==========================================
+        http.authorizeHttpRequests(auth -> auth
+                // preflight
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
 
-        // =========================
-        // ⚠️ 테스트용(임시): 로그인 없이 전부 허용
-        // - 프론트/포스트맨 개발 초반 편의를 위한 설정
-        // - 테스트 종료 후 위 "정상 코드"로 되돌릴 것
-        // =========================
+                // swagger / h2
+                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                .requestMatchers("/h2-console/**").permitAll()
+
+                // auth
+                .requestMatchers("/api/v1/auth/**").permitAll()
+
+                // 닉네임/이메일 중복 체크(네 코드 기준)
+                .requestMatchers(HttpMethod.GET, "/api/v1/members/check-nickname").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/auth/check-email").permitAll()
+
+                // ======================
+                // 게임 조회/검색 (공개)
+                // ======================
+                .requestMatchers(HttpMethod.GET, "/api/v1/games/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/genres/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/platforms/**").permitAll()
+
+                // ======================
+                // 게시글/댓글 조회 (공개)
+                // ======================
+                .requestMatchers(HttpMethod.GET, "/api/v1/posts/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/v1/posts/*/comments/**").permitAll()
+
+                // ======================
+                // 리뷰 조회 (공개)
+                // ======================
+                .requestMatchers(HttpMethod.GET, "/api/v1/reviews/**").permitAll()
+
+                // 그 외 /api/** 는 로그인 필요
+                .requestMatchers("/api/**").authenticated()
+
+                // 나머지는 열어둠(정적 리소스 등)
+                .anyRequest().permitAll()
+        );
+
+        /*
+        // ==========================================
+        // 🧪 테스트용(임시): 로그인 없이 전부 허용
+        // - 팀원들이 초반에 Postman으로 편하게 테스트할 때만 사용
+        // - 사용할 땐 위 "정상 코드" authorizeHttpRequests 블록을 주석 처리하고
+        //   이 블록을 켜서 사용
+        // ==========================================
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .anyRequest().permitAll()
         );
+        */
 
         return http.build();
     }


### PR DESCRIPTION
## 👩‍💻 요구 사항과 구현 내용

### ✅ Rq.getActor 구현
- `SecurityContextHolder.getContext().getAuthentication().getPrincipal()`이 **SecurityUser**일 때만 캐스팅
- `SecurityUser(id/email/nickname)` → `new Member(id, email, nickname)`로 변환해 반환
- 인증 정보가 없으면 `null` 반환

### ✅ Member 생성자 추가 (Actor 변환용)
- `Member(int id, String email, String nickname)` 생성자 추가
- `Rq.getActor()`에서 DB 조회 없이 “요청 주체(Actor)”를 만들 수 있도록 지원

### ✅ SecurityConfig 권한 정책 정리
- `/api/v1/auth/**` 및 중복 체크 API는 `permitAll()`
- 게임/게시글/댓글/리뷰 **조회(GET)** 는 `permitAll()`
- 그 외 `/api/**`는 `authenticated()`
- 인증/권한 실패 응답을 `RsData(JSON)`로 통일
