### PR TITLE
[Refactor] PostController Rq 주입 방식으로 수정

### DIFF
--- a/src/main/java/com/back/domain/post/post/controller/PostController.java
+++ b/src/main/java/com/back/domain/post/post/controller/PostController.java
@@ -10,19 +10,15 @@ import com.back.domain.post.post.service.PostService;
 import com.back.domain.tag.tag.entity.Tag;
 import com.back.domain.tag.tag.service.TagService;
 import com.back.global.exception.ServiceException;
+import com.back.global.rq.Rq;
 import com.back.global.rsData.RsData;
-import com.back.global.security.CustomAuthenticationFilter;
-import com.back.global.security.SecurityUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/posts")
@@ -31,86 +27,93 @@ public class PostController {
     private final PostService postService;
     private final TagService tagService;
     private final MemberService memberService;
+    private final Rq rq;
 
     @GetMapping
     public RsData<Page<PostDto>> getItems(
-            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC)Pageable pageable
-            ){
+            @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
         Page<Post> items = postService.findAll(pageable);
-
         Page<PostDto> postDtos = items.map(PostDto::new);
+
         return new RsData<>("200-1", "게시글 목록 조회", postDtos);
     }
 
     @GetMapping("/{id}")
     public PostDto getItem(@PathVariable int id) {
         Post post = postService.findById(id)
-                .orElseThrow(()-> new ServiceException("404-1", "해당 게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new ServiceException("404-1", "해당 게시글을 찾을 수 없습니다."));
 
         return new PostDto(post);
     }
 
     @PostMapping
     public RsData<PostDto> create(
-            @AuthenticationPrincipal SecurityUser user,
             @RequestBody @Valid PostCreateRequest request
     ) {
-        if(user == null){
+        Member actor = rq.getActor();
+        if (actor == null) {
             throw new ServiceException("401-1", "로그인이 필요합니다.");
         }
-        Member author = memberService.findById(user.getId())
-                .orElseThrow(()->new ServiceException("404-1", "회원 정보를 찾을 수 없습니다."));
+
+        Member author = memberService.findById(actor.getId())
+                .orElseThrow(() -> new ServiceException("404-1", "회원 정보를 찾을 수 없습니다."));
 
         Post post = postService.write(author, request.title(), request.content(), request.tags());
+
         return new RsData<>("201-1", "게시글이 작성되었습니다.", new PostDto(post));
     }
 
     @PutMapping("/{id}")
     public RsData<PostDto> modify(
             @PathVariable int id,
-            @AuthenticationPrincipal SecurityUser user,
             @RequestBody @Valid PostModifyRequest request
     ) {
-        Post post = postService.findById(id)
-                .orElseThrow(()-> new ServiceException("404-1", "해당 게시글을 찾을 수 없습니다."));
+        Member actor = rq.getActor();
+        if (actor == null) {
+            throw new ServiceException("401-1", "로그인이 필요합니다.");
+        }
 
-        Member author = memberService.findById(user.getId()).get();
+        Post post = postService.findById(id)
+                .orElseThrow(() -> new ServiceException("404-1", "해당 게시글을 찾을 수 없습니다."));
+
+        Member author = memberService.findById(actor.getId())
+                .orElseThrow(() -> new ServiceException("404-1", "회원 정보를 찾을 수 없습니다."));
 
         postService.checkPermission(post, author);
-
         postService.modify(post, request);
 
-        return new RsData<>("200-1", "%d번 게시글이 수정되었습니다.".formatted(id),new PostDto(post));
+        return new RsData<>("200-1", "%d번 게시글이 수정되었습니다.".formatted(id), new PostDto(post));
     }
 
     @DeleteMapping("/{id}")
     public RsData<Void> delete(
-            @PathVariable int id,
-            @AuthenticationPrincipal SecurityUser user
-    ){
-        Post post = postService.findById(id)
-                        .orElseThrow(()-> new ServiceException("404-1", "해당 게시글을 찾을 수 없습니다."));
+            @PathVariable int id
+    ) {
+        Member actor = rq.getActor();
+        if (actor == null) {
+            throw new ServiceException("401-1", "로그인이 필요합니다.");
+        }
 
-        Member author = memberService.findById(user.getId()).get();
+        Post post = postService.findById(id)
+                .orElseThrow(() -> new ServiceException("404-1", "해당 게시글을 찾을 수 없습니다."));
+
+        Member author = memberService.findById(actor.getId())
+                .orElseThrow(() -> new ServiceException("404-1", "회원 정보를 찾을 수 없습니다."));
 
         postService.checkPermission(post, author);
-
         postService.delete(post);
 
-        return new RsData<>(
-                "200-1",
-                "%d번 글이 삭제되었습니다.".formatted(id)
-        );
+        return new RsData<>("200-1", "%d번 글이 삭제되었습니다.".formatted(id));
     }
 
     @GetMapping("/search")
     public RsData<Page<PostDto>> searchByTitle(
             @RequestParam String keyword,
             @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
-    ){
-
+    ) {
         Page<Post> page = postService.searchByTitle(keyword, pageable);
-        Page<PostDto> postDtos = page.map(PostDto :: new);
+        Page<PostDto> postDtos = page.map(PostDto::new);
 
         return new RsData<>("200-1", "제목 조회", postDtos);
     }
@@ -119,7 +122,7 @@ public class PostController {
     public RsData<Page<PostDto>> searchByTag(
             @RequestParam String tagName,
             @PageableDefault(size = 10, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
-    ){
+    ) {
         Page<PostDto> postDtos = postService.searchByTagName(tagName, pageable)
                 .map(PostDto::new);
 
@@ -130,34 +133,32 @@ public class PostController {
     public RsData<Void> addTag(
             @PathVariable int id,
             @PathVariable int tagId
-    ){
+    ) {
+        // 정책상 로그인 필요하게 둘 거면 여기서도 actor 체크 가능
+        // Member actor = rq.getActor();
+        // if (actor == null) throw new ServiceException("401-1", "로그인이 필요합니다.");
+
         postService.addTag(id, tagId);
 
-        return new RsData<>(
-                "200-1",
-                "%d번 게시글에 %d번 태그가 추가되었습니다.".formatted(id, tagId)
-        );
+        return new RsData<>("200-1", "%d번 게시글에 %d번 태그가 추가되었습니다.".formatted(id, tagId));
     }
 
     @DeleteMapping("/{id}/tags/{tagId}")
     public RsData<Void> deleteTag(
             @PathVariable int id,
             @PathVariable int tagId
-    ){
+    ) {
+        // 정책상 로그인 필요하게 둘 거면 여기서도 actor 체크 가능
+        // Member actor = rq.getActor();
+        // if (actor == null) throw new ServiceException("401-1", "로그인이 필요합니다.");
+
         Post post = postService.findById(id)
-                .orElseThrow(()-> new ServiceException("404-1", "해당 게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new ServiceException("404-1", "해당 게시글을 찾을 수 없습니다."));
         Tag tag = tagService.findById(tagId)
-                .orElseThrow(()-> new ServiceException("404-2", "해당 태그를 찾을 수 없습니다."));
+                .orElseThrow(() -> new ServiceException("404-2", "해당 태그를 찾을 수 없습니다."));
 
         postService.deleteTag(post, tag);
 
-        return new RsData<>(
-                "200-1",
-                "태그가 게시글에서 제거되었습니다."
-        );
+        return new RsData<>("200-1", "태그가 게시글에서 제거되었습니다.");
     }
-
-
-
-
 }


### PR DESCRIPTION
## 📌 과제 설명
- PostController에서 “로그인 사용자 처리”를 `@AuthenticationPrincipal` 방식 대신 `Rq.getActor()` 방식으로 통일했습니다.

## 👩‍💻 요구 사항과 구현 내용
- **컨트롤러 의존성 변경**
  - `@AuthenticationPrincipal SecurityUser user` 파라미터 제거
  - `Rq rq` 주입 추가 후, 로그인 사용자(Actor)는 `rq.getActor()`로 획득

- **작성/수정/삭제 인증 처리 통일**
  - `POST /api/v1/posts` 작성
    - `Member actor = rq.getActor()`로 로그인 여부 확인 (없으면 401)
    - 필요한 경우 `memberService.findById(actor.getId())`로 영속 엔티티 조회 후 서비스 호출
  - `PUT /api/v1/posts/{id}` 수정
    - `rq.getActor()` 기반으로 작성자 권한 체크 흐름 유지
  - `DELETE /api/v1/posts/{id}` 삭제
    - `rq.getActor()` 기반으로 작성자 권한 체크 흐름 유지

- **조회 API는 기존 그대로 유지**
  - `GET /api/v1/posts`, `GET /api/v1/posts/{id}`
  - 검색/태그 조회 등 조회성 엔드포인트는 인증 로직 추가 없이 기존 동작 유지
