### PR TITLE
[Feat] Test 케이스 작성 및 핸들러 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
-	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-webmvc")
 
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,19 +34,19 @@ dependencies {
 
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
-	implementation("org.springframework.boot:spring-boot-starter-webmvc")
+	implementation("org.springframework.boot:spring-boot-starter-web")
 
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0")
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.0")
 
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 
 	runtimeOnly("com.h2database:h2")
-    developmentOnly("org.springframework.boot:spring-boot-h2console")
+	developmentOnly("org.springframework.boot:spring-boot-h2console")
 
-    compileOnly("org.projectlombok:lombok")
+	compileOnly("org.projectlombok:lombok")
 	annotationProcessor("org.projectlombok:lombok")
 
-	
+
 	testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-validation-test")
@@ -55,10 +55,10 @@ dependencies {
 
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
-    implementation("org.springframework.boot:spring-boot-starter-security")
-    testImplementation("org.springframework.boot:spring-boot-starter-security-test")
+	implementation("org.springframework.boot:spring-boot-starter-security")
+	testImplementation("org.springframework.boot:spring-boot-starter-security-test")
 
-    implementation("org.springframework.boot:spring-boot-starter-restclient")
+	implementation("org.springframework.boot:spring-boot-starter-restclient")
 
 	// 1. QueryDSL 라이브러리
 	implementation("com.querydsl:querydsl-jpa:5.1.0:jakarta")
@@ -68,17 +68,17 @@ dependencies {
 	annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 	annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 
-    //caffeine
-    implementation("org.springframework.boot:spring-boot-starter-cache")
-    implementation("com.github.ben-manes.caffeine:caffeine")
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+	//caffeine
+	implementation("org.springframework.boot:spring-boot-starter-cache")
+	implementation("com.github.ben-manes.caffeine:caffeine")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
 
-    //RestClient test용
-    testImplementation(platform("com.squareup.okhttp3:okhttp-bom:5.3.2"))
-    testImplementation("com.squareup.okhttp3:mockwebserver")
+	//RestClient test용
+	testImplementation(platform("com.squareup.okhttp3:okhttp-bom:5.3.2"))
+	testImplementation("com.squareup.okhttp3:mockwebserver")
 
-    //Guava rate limiter
-    implementation("com.google.guava:guava:33.4.0-jre")
+	//Guava rate limiter
+	implementation("com.google.guava:guava:33.4.0-jre")
 
 }
 
@@ -94,5 +94,3 @@ sourceSets {
 		}
 	}
 }
-
-

--- a/src/main/java/com/back/global/globalExceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/back/global/globalExceptionHandler/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package com.back.global.globalExceptionHandler;
 import com.back.global.exception.ServiceException;
 import com.back.global.rsData.RsData;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -39,6 +41,21 @@ public class GlobalExceptionHandler {
                 .stream()
                 .sorted(Comparator.comparing(FieldError::getField))
                 .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining("\n"));
+
+        return new ResponseEntity<>(
+                new RsData<>("400-1", message),
+                BAD_REQUEST
+        );
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<RsData<Void>> handle(ConstraintViolationException ex) {
+
+        String message = ex.getConstraintViolations()
+                .stream()
+                .sorted(Comparator.comparing(v -> v.getPropertyPath().toString()))
+                .map(ConstraintViolation::getMessage)
                 .collect(Collectors.joining("\n"));
 
         return new ResponseEntity<>(

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -4,3 +4,15 @@ spring:
     username: sa
     password:
     driver-class-name: org.h2.Driver
+
+custom:
+  jwt:
+    secretKey: "test-secret-key-32bytes-minimum-xxxxxxxxxxxx"
+  accessToken:
+    expirationSeconds: 300
+
+igdb:
+  base-url: "https://api.igdb.com/v4"
+  client-id: "dummy"
+  client-secret: "dummy"
+  token-url: "https://id.twitch.tv/oauth2/token"

--- a/src/test/java/com/back/domain/member/auth/controller/ApiV1AuthControllerTest.java
+++ b/src/test/java/com/back/domain/member/auth/controller/ApiV1AuthControllerTest.java
@@ -1,0 +1,119 @@
+package com.back.domain.member.auth.controller;
+
+import com.back.domain.game.game.service.GenreSyncService;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class ApiV1AuthControllerTest {
+
+    @Autowired MockMvc mvc;
+    private final ObjectMapper om = new ObjectMapper();
+    @Autowired MemberRepository memberRepository;
+
+    @MockitoBean
+    GenreSyncService genreSyncService;
+
+    @BeforeEach
+    void clear() {
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("이메일 중복 체크: 가입 전이면 available=true")
+    void checkEmail_available_true() throws Exception {
+        mvc.perform(get("/api/v1/auth/check-email")
+                        .param("email", "newuser@test.com"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.data.available").value(true));
+    }
+
+    @Test
+    @DisplayName("회원가입 성공: DB에 회원이 저장된다")
+    void signup_success() throws Exception {
+        var body = Map.of(
+                "email", "user1@test.com",
+                "password", "1234",
+                "nickname", "유저1"
+        );
+
+        mvc.perform(post("/api/v1/auth/signup")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(body)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.resultCode").value("201-1"));
+
+        assertThat(memberRepository.findByEmail("user1@test.com")).isPresent();
+    }
+
+    @Test
+    @DisplayName("로그인 성공: Set-Cookie에 apiKey/accessToken이 내려온다")
+    void login_sets_cookies() throws Exception {
+        // 1) 먼저 가입
+        mvc.perform(post("/api/v1/auth/signup")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(Map.of(
+                                "email", "user2@test.com",
+                                "password", "1234",
+                                "nickname", "유저2"
+                        ))))
+                .andExpect(status().isCreated());
+
+        // 2) 로그인
+        var result = mvc.perform(post("/api/v1/auth/login")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(Map.of(
+                                "email", "user2@test.com",
+                                "password", "1234"
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andReturn();
+
+        List<String> setCookies = result.getResponse().getHeaders("Set-Cookie");
+        String all = String.join(";", setCookies);
+
+        assertThat(all).contains("apiKey=");
+        assertThat(all).contains("accessToken=");
+    }
+
+    @Test
+    @DisplayName("로그아웃: 쿠키 삭제(Set-Cookie Max-Age=0) 내려온다")
+    void logout_deletes_cookies() throws Exception {
+        var result = mvc.perform(post("/api/v1/auth/logout").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andReturn();
+
+        List<String> setCookies = result.getResponse().getHeaders("Set-Cookie");
+        String all = String.join(";", setCookies);
+
+        assertThat(all).contains("Max-Age=0");
+    }
+}

--- a/src/test/java/com/back/domain/member/member/controller/ApiV1MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/ApiV1MemberControllerTest.java
@@ -1,0 +1,236 @@
+package com.back.domain.member.member.controller;
+
+import com.back.domain.game.game.service.GenreSyncService;
+import com.back.domain.member.member.repository.MemberRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class ApiV1MemberControllerTest {
+
+    @Autowired MockMvc mvc;
+    private final ObjectMapper om = new ObjectMapper();
+    @Autowired MemberRepository memberRepository;
+
+    // 서버 뜰 때 GenreInitializer(@PostConstruct)에서 syncGenres() 호출하는 거 막기
+    @MockitoBean
+    GenreSyncService genreSyncService;
+
+    @BeforeEach
+    void clear() {
+        memberRepository.deleteAll();
+    }
+
+    // --- helpers ---
+    private void signup(String email, String password, String nickname) throws Exception {
+        mvc.perform(post("/api/v1/auth/signup")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(Map.of(
+                                "email", email,
+                                "password", password,
+                                "nickname", nickname
+                        ))))
+                .andExpect(status().isCreated());
+    }
+
+    private Cookie[] loginAndGetCookies(String email, String password) throws Exception {
+        var result = mvc.perform(post("/api/v1/auth/login")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(Map.of(
+                                "email", email,
+                                "password", password
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andReturn();
+
+        Cookie[] cookies = result.getResponse().getCookies();
+        assertThat(cookies).isNotEmpty();
+        return cookies;
+    }
+
+    // --- tests ---
+
+    @Test
+    @DisplayName("닉네임 중복 체크: 사용 가능하면 available=true")
+    void checkNickname_available_true() throws Exception {
+        mvc.perform(get("/api/v1/members/check-nickname")
+                        .param("nickname", "새닉네임"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.data.available").value(true));
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 체크: 이미 사용 중이면 available=false")
+    void checkNickname_available_false() throws Exception {
+        signup("user@test.com", "1234", "중복닉"); // ✅ 2글자 이상
+        mvc.perform(get("/api/v1/members/check-nickname")
+                        .param("nickname", "중복닉"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.data.available").value(false));
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 체크: 빈 값이면 400-1")
+    void checkNickname_validation_fail() throws Exception {
+        mvc.perform(get("/api/v1/members/check-nickname")
+                        .param("nickname", ""))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.resultCode").value("400-1"));
+    }
+
+    @Test
+    @DisplayName("/me: 로그인 안 하면 401-1")
+    void me_unauthorized() throws Exception {
+        mvc.perform(get("/api/v1/members/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.resultCode").value("401-1"));
+    }
+
+    @Test
+    @DisplayName("/me: 로그인 하면 내 정보 조회 200-1")
+    void me_authorized() throws Exception {
+        // ✅ 이메일/닉네임 규칙 맞추고, 로그인 이메일도 동일하게
+        signup("me@test.com", "1234", "나나"); // ✅ 2글자 이상
+        Cookie[] cookies = loginAndGetCookies("me@test.com", "1234");
+
+        mvc.perform(get("/api/v1/members/me").cookie(cookies))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"))
+                .andExpect(jsonPath("$.data.email").value("me@test.com"))
+                .andExpect(jsonPath("$.data.nickname").value("나나"));
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경: 로그인 안 하면 401-1")
+    void changePassword_unauthorized() throws Exception {
+        mvc.perform(put("/api/v1/members/me/password")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(Map.of(
+                                "oldPassword", "1234",
+                                "newPassword", "5678"
+                        ))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.resultCode").value("401-1"));
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 성공: 이후 새 비밀번호로 로그인 가능")
+    void changePassword_success() throws Exception {
+        signup("pw@test.com", "1234", "비번"); // ✅ 2글자 이상
+        Cookie[] cookies = loginAndGetCookies("pw@test.com", "1234");
+
+        mvc.perform(put("/api/v1/members/me/password")
+                        .with(csrf())
+                        .cookie(cookies)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(Map.of(
+                                "oldPassword", "1234",
+                                "newPassword", "5678"
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"));
+
+        // 새 비번으로 로그인 성공
+        mvc.perform(post("/api/v1/auth/login")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(Map.of(
+                                "email", "pw@test.com",
+                                "password", "5678"
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.resultCode").value("200-1"));
+
+        // 기존 비번으로 로그인 실패
+        mvc.perform(post("/api/v1/auth/login")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(Map.of(
+                                "email", "pw@test.com",
+                                "password", "1234"
+                        ))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.resultCode").value("401-1"));
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경: oldPassword 틀리면 401-2")
+    void changePassword_wrong_old_password() throws Exception {
+        signup("pw2@test.com", "1234", "비번2"); // ✅
+        Cookie[] cookies = loginAndGetCookies("pw2@test.com", "1234");
+
+        mvc.perform(put("/api/v1/members/me/password")
+                        .with(csrf())
+                        .cookie(cookies)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(Map.of(
+                                "oldPassword", "0000",
+                                "newPassword", "5678"
+                        ))))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.resultCode").value("401-2"));
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경: 새 비번이 기존과 같으면 400-2")
+    void changePassword_same_as_old() throws Exception {
+        signup("pw3@test.com", "1234", "비번3"); // ✅
+        Cookie[] cookies = loginAndGetCookies("pw3@test.com", "1234");
+
+        mvc.perform(put("/api/v1/members/me/password")
+                        .with(csrf())
+                        .cookie(cookies)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(Map.of(
+                                "oldPassword", "1234",
+                                "newPassword", "1234"
+                        ))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.resultCode").value("400-2"));
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경: validation 실패(빈 값 등)면 400-1")
+    void changePassword_validation_fail() throws Exception {
+        signup("pw4@test.com", "1234", "비번4"); // ✅
+        Cookie[] cookies = loginAndGetCookies("pw4@test.com", "1234");
+
+        mvc.perform(put("/api/v1/members/me/password")
+                        .with(csrf())
+                        .cookie(cookies)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(Map.of(
+                                "oldPassword", "",
+                                "newPassword", ""
+                        ))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.resultCode").value("400-1"));
+    }
+}


### PR DESCRIPTION
## 📌 과제 설명
MockMvc 기반 컨트롤러 테스트를 추가하면서, 요청 검증 실패 시에도 응답이 `RsData` 포맷으로 일관되게 내려오도록 예외 처리를 보완했습니다.  
특히 `@RequestParam` 검증 실패 시 발생하는 `ConstraintViolationException`을 `GlobalExceptionHandler`에서 처리하여 테스트가 안정적으로 통과하도록 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용
- **컨트롤러 테스트 추가**
  - Auth 관련 엔드포인트 테스트 작성  
    - 이메일 중복 체크 / 회원가입 / 로그인 쿠키 발급 / 로그아웃 쿠키 삭제
  - Member 관련 엔드포인트 테스트 작성  
    - 닉네임 중복 체크 / `/me` 인증 여부 / 비밀번호 변경(성공/실패/validation) 케이스
  - 테스트 실행 전 DB 초기화를 위해 `@BeforeEach`에서 `memberRepository.deleteAll()` 수행

- **예외 처리 보완**
  - `ConstraintViolationException` 핸들러 추가
    - `@RequestParam` 또는 메서드 파라미터 검증(@NotBlank, @Size 등) 실패 시 발생하는 예외를 처리
    - 기존 에러 응답 포맷인 `RsData("400-1", message)` 형태로 반환하도록 통일
