### PR TITLE
112 feat 내 라이브러리 기반 게임 추천

### DIFF
--- a/src/main/java/com/back/domain/game/recommendation/repository/GameVectorRepositoryImpl.java
+++ b/src/main/java/com/back/domain/game/recommendation/repository/GameVectorRepositoryImpl.java
@@ -3,11 +3,14 @@ package com.back.domain.game.recommendation.repository;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 @RequiredArgsConstructor
 public class GameVectorRepositoryImpl implements GameVectorRepositoryCustom {
 
+    private static final int BATCH_SIZE = 50;
     private final EntityManager entityManager;
 
     @Override
@@ -16,20 +19,26 @@ public class GameVectorRepositoryImpl implements GameVectorRepositoryCustom {
             return;
         }
 
-        StringBuilder sql = new StringBuilder(
-                "UPDATE game AS g SET feature_vector = cast(v.vec as vector) FROM (VALUES ");
+        List<Map.Entry<Integer, String>> entries = new ArrayList<>(gameVectorMap.entrySet());
 
-        boolean first = true;
-        for (Map.Entry<Integer, String> entry : gameVectorMap.entrySet()) {
-            if (!first) {
-                sql.append(',');
+        for (int i = 0; i < entries.size(); i += BATCH_SIZE) {
+            List<Map.Entry<Integer, String>> batch = entries.subList(i, Math.min(i + BATCH_SIZE, entries.size()));
+
+            StringBuilder sql = new StringBuilder(
+                    "UPDATE game AS g SET feature_vector = cast(v.vec as vector) FROM (VALUES ");
+
+            boolean first = true;
+            for (Map.Entry<Integer, String> entry : batch) {
+                if (!first) {
+                    sql.append(',');
+                }
+                sql.append('(').append(entry.getKey()).append(",'").append(entry.getValue()).append("')");
+                first = false;
             }
-            sql.append('(').append(entry.getKey()).append(",'").append(entry.getValue()).append("')");
-            first = false;
+
+            sql.append(") AS v(id, vec) WHERE g.id = v.id");
+
+            entityManager.createNativeQuery(sql.toString()).executeUpdate();
         }
-
-        sql.append(") AS v(id, vec) WHERE g.id = v.id");
-
-        entityManager.createNativeQuery(sql.toString()).executeUpdate();
     }
 }

--- a/src/main/java/com/back/global/batch/IgdbSyncJobConfig.java
+++ b/src/main/java/com/back/global/batch/IgdbSyncJobConfig.java
@@ -33,7 +33,8 @@ import org.springframework.transaction.PlatformTransactionManager;
  *     ├─ 5) playerPerspectiveSyncStep  (Tasklet)
  *     ├─ 6) keywordSyncStep            (Tasklet)
  *     ├─ 7) companySyncStep            (Tasklet)
- *     └─ 8) gameSyncStep               (Chunk + 벡터 매핑 갱신 + 벡터 생성)
+ *     ├─ 8) vectorDimensionRefreshStep (Tasklet - 벡터 차원 매핑 1회 갱신)
+ *     └─ 9) gameSyncStep               (Chunk + 벡터 생성)
  */
 @Configuration
 @RequiredArgsConstructor
@@ -81,6 +82,7 @@ public class IgdbSyncJobConfig {
                 .next(playerPerspectiveSyncStep())
                 .next(keywordSyncStep())
                 .next(companySyncStep())
+                .next(vectorDimensionRefreshStep())
                 .next(gameSyncStep())
                 .build();
     }
@@ -131,6 +133,16 @@ public class IgdbSyncJobConfig {
     public Step companySyncStep() {
         return new StepBuilder("companySyncStep", jobRepository)
                 .tasklet(companySyncTasklet, transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Step vectorDimensionRefreshStep() {
+        return new StepBuilder("vectorDimensionRefreshStep", jobRepository)
+                .tasklet((contribution, chunkContext) -> {
+                    vectorDimensionRefresher.refresh();
+                    return org.springframework.batch.infrastructure.repeat.RepeatStatus.FINISHED;
+                }, transactionManager)
                 .build();
     }
 
@@ -192,8 +204,7 @@ public class IgdbSyncJobConfig {
                 gameCompanyRepository,
                 gameExternalIdRepository,
                 gameVectorRepository,
-                gameVectorService,
-                vectorDimensionRefresher
+                gameVectorService
         );
     }
 }

--- a/src/main/java/com/back/global/batch/writer/IgdbGameUpsertWriter.java
+++ b/src/main/java/com/back/global/batch/writer/IgdbGameUpsertWriter.java
@@ -5,7 +5,6 @@ import com.back.domain.game.game.repository.*;
 import com.back.domain.game.recommendation.repository.GameVectorRepository;
 import com.back.domain.game.recommendation.service.GameVectorService;
 import com.back.global.batch.dto.GameBatchItem;
-import com.back.global.vector.VectorDimensionConfig.VectorDimensionRefresher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.infrastructure.item.Chunk;
@@ -33,7 +32,6 @@ public class IgdbGameUpsertWriter implements ItemWriter<GameBatchItem> {
     private final GameExternalIdRepository gameExternalIdRepository;
     private final GameVectorRepository gameVectorRepository;
     private final GameVectorService gameVectorService;
-    private final VectorDimensionRefresher vectorDimensionRefresher;
 
     @Override
     public void write(Chunk<? extends GameBatchItem> chunk) {
@@ -129,10 +127,7 @@ public class IgdbGameUpsertWriter implements ItemWriter<GameBatchItem> {
         if (!allCompanies.isEmpty()) gameCompanyRepository.saveAll(allCompanies);
         if (!allExternalIds.isEmpty()) gameExternalIdRepository.saveAll(allExternalIds);
 
-        // 6. 벡터 차원 매핑 갱신 (매 chunk마다 최신 마스터 데이터 반영)
-        vectorDimensionRefresher.refresh();
-
-        // 7. 게임 피처 벡터 벌크 생성 (메모리에 있는 속성 데이터로 바로 생성, 1회 UPDATE)
+        // 6. 게임 피처 벡터 벌크 생성 (메모리에 있는 속성 데이터로 바로 생성)
         Map<Integer, String> vectorMap = new HashMap<>();
         for (GameBatchItem item : chunk) {
             Game game = persistedMap.get(item.getGame().getIgdbId());

--- a/src/test/java/com/back/global/batch/IgdbGameUpsertWriterTest.java
+++ b/src/test/java/com/back/global/batch/IgdbGameUpsertWriterTest.java
@@ -65,8 +65,7 @@ class IgdbGameUpsertWriterTest {
                 gameCompanyRepository,
                 gameExternalIdRepository,
                 gameVectorRepository,
-                gameVectorService,
-                vectorDimensionRefresher
+                gameVectorService
         );
     }
 


### PR DESCRIPTION
## 📌 과제 설명
- ec2에서 OutOfMemoryError 해결

## 👩‍💻 요구 사항과 구현 내용
문제의 흐름
  1. chunk size = 500 (한 번에 500개 게임 처리)
  2. 각 게임마다 160차원 벡터 문자열 생성 ([0.0,1.0,0.0,...] → 약 650바이트)
  3. bulkUpdateFeatureVectors가 500개 벡터를 하나의 VALUES 절로 합침
  4. 결과적으로 ~325KB+ 크기의 SQL 문자열 생성
  5. PostgreSQL JDBC 드라이버가 이 거대한 SQL을 파싱하다가 OOM 발생

해결책
bulkUpdateFeatureVectors에 서브 배칭 추가