### PR TITLE
[Refactor] feature_vector 업데이트를 PreparedStatement batch로 최적화

### DIFF
--- a/src/main/java/com/back/domain/game/recommendation/repository/GameVectorRepositoryImpl.java
+++ b/src/main/java/com/back/domain/game/recommendation/repository/GameVectorRepositoryImpl.java
@@ -15,9 +15,7 @@ public class GameVectorRepositoryImpl implements GameVectorRepositoryCustom {
 
     @Override
     public void bulkUpdateFeatureVectors(Map<Integer, String> gameVectorMap) {
-        if (gameVectorMap.isEmpty()) {
-            return;
-        }
+        if (gameVectorMap.isEmpty()) return;
 
         entityManager.unwrap(Session.class).doWork(connection -> {
             String sql = "UPDATE game SET feature_vector = cast(? as vector) WHERE id = ?";

--- a/src/main/java/com/back/domain/game/recommendation/repository/GameVectorRepositoryImpl.java
+++ b/src/main/java/com/back/domain/game/recommendation/repository/GameVectorRepositoryImpl.java
@@ -2,15 +2,15 @@ package com.back.domain.game.recommendation.repository;
 
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.Session;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.sql.PreparedStatement;
 import java.util.Map;
 
 @RequiredArgsConstructor
 public class GameVectorRepositoryImpl implements GameVectorRepositoryCustom {
 
-    private static final int BATCH_SIZE = 50;
+    private static final int BATCH_SIZE = 500;
     private final EntityManager entityManager;
 
     @Override
@@ -19,26 +19,22 @@ public class GameVectorRepositoryImpl implements GameVectorRepositoryCustom {
             return;
         }
 
-        List<Map.Entry<Integer, String>> entries = new ArrayList<>(gameVectorMap.entrySet());
+        entityManager.unwrap(Session.class).doWork(connection -> {
+            String sql = "UPDATE game SET feature_vector = cast(? as vector) WHERE id = ?";
+            try (PreparedStatement ps = connection.prepareStatement(sql)) {
+                int count = 0;
+                for (Map.Entry<Integer, String> entry : gameVectorMap.entrySet()) {
+                    ps.setString(1, entry.getValue());
+                    ps.setInt(2, entry.getKey());
+                    ps.addBatch();
 
-        for (int i = 0; i < entries.size(); i += BATCH_SIZE) {
-            List<Map.Entry<Integer, String>> batch = entries.subList(i, Math.min(i + BATCH_SIZE, entries.size()));
-
-            StringBuilder sql = new StringBuilder(
-                    "UPDATE game AS g SET feature_vector = cast(v.vec as vector) FROM (VALUES ");
-
-            boolean first = true;
-            for (Map.Entry<Integer, String> entry : batch) {
-                if (!first) {
-                    sql.append(',');
+                    if (++count % BATCH_SIZE == 0) {
+                        ps.executeBatch();
+                        ps.clearBatch();
+                    }
                 }
-                sql.append('(').append(entry.getKey()).append(",'").append(entry.getValue()).append("')");
-                first = false;
+                ps.executeBatch();
             }
-
-            sql.append(") AS v(id, vec) WHERE g.id = v.id");
-
-            entityManager.createNativeQuery(sql.toString()).executeUpdate();
-        }
+        });
     }
 }

--- a/src/test/java/com/back/domain/game/recommendation/service/GameRecommendationIntegrationTest.java
+++ b/src/test/java/com/back/domain/game/recommendation/service/GameRecommendationIntegrationTest.java
@@ -271,6 +271,7 @@ class GameRecommendationIntegrationTest {
             Game game2 = gameRepository.save(
                     Game.createGame(101L, "Bulk2", "s", null, 1700000000L, null, null, null, null));
 
+            em.flush();
             // bulkUpdate로 벡터 저장
             gameVectorRepository.bulkUpdateFeatureVectors(Map.of(
                     game1.getId(), vectorToString(rpgVector()),
@@ -317,6 +318,8 @@ class GameRecommendationIntegrationTest {
         Game game = Game.createGame(igdbId, name, "summary", null, 1700000000L,
                 null, rating, null, null);
         game = gameRepository.save(game);
+        em.flush();
+
         gameVectorRepository.bulkUpdateFeatureVectors(
                 Map.of(game.getId(), vectorToString(vector)));
         em.flush();


### PR DESCRIPTION
## 배경 / 문제

IGDB 게임 배치에서 `feature_vector` 업데이트(Writer 6번) 추가 이후 처리 시간이 **약 20분대 → 50분대**로 증가
`UPDATE ... FROM (VALUES ...)` 형태의 **동적 SQL 문자열 생성 + 작은 batch size(50)** (추정)

* 긴 SQL 파싱/플래닝 비용이 반복 발생
* Java 측에서도 SQL 문자열/벡터 문자열 조립으로 GC 부담이 커짐
* DB round-trip이 대량으로 발생한 점이 병목

---

## 변경 내용

* `bulkUpdateFeatureVectors` 구현을 **VALUES 기반 동적 SQL 조립 방식**에서
  **PreparedStatement 기반 JDBC batch 업데이트 방식**으로 변경
* SQL을 고정 형태로 유지(`UPDATE game SET feature_vector = cast(? as vector) WHERE id = ?`)하고
  파라미터 바인딩 + `executeBatch()`로 묶어서 전송하도록 개선
