### PR TITLE
vector update안되는 문제 수정

### DIFF
--- a/src/main/java/com/back/domain/game/recommendation/repository/GameVectorRepositoryImpl.java
+++ b/src/main/java/com/back/domain/game/recommendation/repository/GameVectorRepositoryImpl.java
@@ -17,6 +17,8 @@ public class GameVectorRepositoryImpl implements GameVectorRepositoryCustom {
     public void bulkUpdateFeatureVectors(Map<Integer, String> gameVectorMap) {
         if (gameVectorMap.isEmpty()) return;
 
+        entityManager.flush();
+
         entityManager.unwrap(Session.class).doWork(connection -> {
             String sql = "UPDATE game SET feature_vector = cast(? as vector) WHERE id = ?";
             try (PreparedStatement ps = connection.prepareStatement(sql)) {

--- a/src/test/java/com/back/domain/game/recommendation/service/GameRecommendationIntegrationTest.java
+++ b/src/test/java/com/back/domain/game/recommendation/service/GameRecommendationIntegrationTest.java
@@ -272,12 +272,11 @@ class GameRecommendationIntegrationTest {
                     Game.createGame(101L, "Bulk2", "s", null, 1700000000L, null, null, null, null));
 
             em.flush();
-            // bulkUpdate로 벡터 저장
+            // bulkUpdate로 벡터 저장 (내부에서 flush 후 JDBC batch UPDATE)
             gameVectorRepository.bulkUpdateFeatureVectors(Map.of(
                     game1.getId(), vectorToString(rpgVector()),
                     game2.getId(), vectorToString(fpsVector())
             ));
-            em.flush();
             em.clear();
             // rpgVector 기준 검색 → Bulk1(RPG)이 Bulk2(FPS)보다 유사도 높음
             Game searchTarget = saveGameWithVector(102L, "SearchTarget", rpgVector());
@@ -318,11 +317,10 @@ class GameRecommendationIntegrationTest {
         Game game = Game.createGame(igdbId, name, "summary", null, 1700000000L,
                 null, rating, null, null);
         game = gameRepository.save(game);
-        em.flush();
 
+        // bulkUpdateFeatureVectors 내부에서 flush 후 JDBC batch UPDATE 실행
         gameVectorRepository.bulkUpdateFeatureVectors(
                 Map.of(game.getId(), vectorToString(vector)));
-        em.flush();
         em.clear();
         return game;
     }


### PR DESCRIPTION
doWork()문제
Writer의 실행 순서를 보면

  1. gameRepository.save() → Hibernate 영속성 컨텍스트에만 등록 (실제 INSERT는 아직 안 됨)        
  2. saveAll() × 8 → 마찬가지로 flush 대기                                                
  3. bulkUpdateFeatureVectors() → doWork()로 raw JDBC UPDATE 실행                                      
     → UPDATE game SET feature_vector = ... WHERE id = ?                                                  
     → 그런데 game 테이블에 아직 INSERT가 안 됐으니 WHERE id = ?에 매칭되는 row가 없음
     → 0 rows affected (무시됨)
  4. 트랜잭션 커밋 시 flush → 이제서야 INSERT 실행 → 하지만 벡터 UPDATE는 이미 끝남
  Session.doWork()는 flush 없이 raw JDBC를 바로 실행함

bulkUpdateFeatureVectors에서 dowork전에 flush해줘야함