### PR TITLE
[Refactor] 벡터쿼리 최적화 - 스테이징테이블 사용

### DIFF
--- a/src/main/java/com/back/domain/game/recommendation/repository/GameVectorRepositoryImpl.java
+++ b/src/main/java/com/back/domain/game/recommendation/repository/GameVectorRepositoryImpl.java
@@ -20,12 +20,18 @@ public class GameVectorRepositoryImpl implements GameVectorRepositoryCustom {
         entityManager.flush();
 
         entityManager.unwrap(Session.class).doWork(connection -> {
-            String sql = "UPDATE game SET feature_vector = cast(? as vector) WHERE id = ?";
-            try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            // 1. TRUNCATE staging
+            try (var stmt = connection.createStatement()) {
+                stmt.execute("TRUNCATE game_vector_staging");
+            }
+
+            // 2. Batch INSERT into staging (reWriteBatchedInserts 활용)
+            String insertSql = "INSERT INTO game_vector_staging (game_id, feature_vector) VALUES (?, ?)";
+            try (PreparedStatement ps = connection.prepareStatement(insertSql)) {
                 int count = 0;
                 for (Map.Entry<Integer, String> entry : gameVectorMap.entrySet()) {
-                    ps.setString(1, entry.getValue());
-                    ps.setInt(2, entry.getKey());
+                    ps.setInt(1, entry.getKey());
+                    ps.setString(2, entry.getValue());
                     ps.addBatch();
 
                     if (++count % BATCH_SIZE == 0) {
@@ -34,6 +40,19 @@ public class GameVectorRepositoryImpl implements GameVectorRepositoryCustom {
                     }
                 }
                 ps.executeBatch();
+            }
+
+            // 3. UPDATE game JOIN staging
+            try (var stmt = connection.createStatement()) {
+                stmt.execute(
+                        "UPDATE game SET feature_vector = cast(s.feature_vector as vector) " +
+                        "FROM game_vector_staging s WHERE game.id = s.game_id"
+                );
+            }
+
+            // 4. TRUNCATE staging
+            try (var stmt = connection.createStatement()) {
+                stmt.execute("TRUNCATE game_vector_staging");
             }
         });
     }

--- a/src/main/java/com/back/global/batch/IgdbSyncJobConfig.java
+++ b/src/main/java/com/back/global/batch/IgdbSyncJobConfig.java
@@ -12,6 +12,7 @@ import com.back.global.batch.writer.IgdbGameUpsertWriter;
 import com.back.global.igdb.IgdbClient;
 import com.back.global.igdb.dto.IgdbGameDetailDto;
 import com.back.global.igdb.exception.IgdbApiException;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.Job;
@@ -19,22 +20,25 @@ import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.Step;
 import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
- * Job 하나와 Step 8개를 정의하는 설정 클래스
+ * Job 하나와 Step 11개를 정의하는 설정 클래스
  * igdbSyncJob
- *     ├─ 1) genreSyncStep              (Tasklet)
- *     ├─ 2) platformSyncStep           (Tasklet)
- *     ├─ 3) themeSyncStep              (Tasklet)
- *     ├─ 4) gameModeSyncStep           (Tasklet)
- *     ├─ 5) playerPerspectiveSyncStep  (Tasklet)
- *     ├─ 6) keywordSyncStep            (Tasklet)
- *     ├─ 7) companySyncStep            (Tasklet)
- *     ├─ 8) vectorDimensionRefreshStep (Tasklet - 벡터 차원 매핑 1회 갱신)
- *     └─ 9) gameSyncStep               (Chunk + 벡터 생성)
+ *     ├─  1) genreSyncStep              (Tasklet)
+ *     ├─  2) platformSyncStep           (Tasklet)
+ *     ├─  3) themeSyncStep              (Tasklet)
+ *     ├─  4) gameModeSyncStep           (Tasklet)
+ *     ├─  5) playerPerspectiveSyncStep  (Tasklet)
+ *     ├─  6) keywordSyncStep            (Tasklet)
+ *     ├─  7) companySyncStep            (Tasklet)
+ *     ├─  8) vectorDimensionRefreshStep (Tasklet - 벡터 차원 매핑 1회 갱신)
+ *     ├─  9) dropVectorIndexStep        (Tasklet - HNSW 인덱스 DROP)
+ *     ├─ 10) gameSyncStep               (Chunk + 스테이징 테이블 벡터 생성)
+ *     └─ 11) createVectorIndexStep      (Tasklet - HNSW 인덱스 CREATE, 항상 실행)
  */
 @Configuration
 @RequiredArgsConstructor
@@ -70,6 +74,7 @@ public class IgdbSyncJobConfig {
     private final GameVectorRepository gameVectorRepository;
     private final GameVectorService gameVectorService;
     private final com.back.global.vector.VectorDimensionConfig.VectorDimensionRefresher vectorDimensionRefresher;
+    private final EntityManager entityManager;
 
     @Bean
     public Job igdbSyncJob() {
@@ -83,7 +88,10 @@ public class IgdbSyncJobConfig {
                 .next(keywordSyncStep())
                 .next(companySyncStep())
                 .next(vectorDimensionRefreshStep())
+                .next(dropVectorIndexStep())
                 .next(gameSyncStep())
+                .on("*").to(createVectorIndexStep())
+                .end()
                 .build();
     }
 
@@ -141,7 +149,32 @@ public class IgdbSyncJobConfig {
         return new StepBuilder("vectorDimensionRefreshStep", jobRepository)
                 .tasklet((contribution, chunkContext) -> {
                     vectorDimensionRefresher.refresh();
-                    return org.springframework.batch.infrastructure.repeat.RepeatStatus.FINISHED;
+                    return RepeatStatus.FINISHED;
+                }, transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Step dropVectorIndexStep() {
+        return new StepBuilder("dropVectorIndexStep", jobRepository)
+                .tasklet((contribution, chunkContext) -> {
+                    entityManager.createNativeQuery(
+                            "DROP INDEX IF EXISTS ix_game_feature_vector"
+                    ).executeUpdate();
+                    return RepeatStatus.FINISHED;
+                }, transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Step createVectorIndexStep() {
+        return new StepBuilder("createVectorIndexStep", jobRepository)
+                .tasklet((contribution, chunkContext) -> {
+                    entityManager.createNativeQuery(
+                            "CREATE INDEX IF NOT EXISTS ix_game_feature_vector " +
+                            "ON game USING hnsw (feature_vector vector_cosine_ops)"
+                    ).executeUpdate();
+                    return RepeatStatus.FINISHED;
                 }, transactionManager)
                 .build();
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/back
+    url: jdbc:postgresql://localhost:5432/back?reWriteBatchedInserts=true
     username: back
     password: back1234
     driver-class-name: org.postgresql.Driver

--- a/src/main/resources/db/migration/V6__add_game_vector_staging.sql
+++ b/src/main/resources/db/migration/V6__add_game_vector_staging.sql
@@ -1,0 +1,6 @@
+-- 벡터 벌크 업데이트용 스테이징 테이블
+-- 배치에서 TRUNCATE → batch INSERT → UPDATE game JOIN staging → TRUNCATE 패턴으로 사용
+CREATE TABLE game_vector_staging (
+    game_id      INT  NOT NULL,
+    feature_vector TEXT NOT NULL
+);


### PR DESCRIPTION
- 스테이징 테이블 방식으로 변경 — TRUNCATE staging → batch INSERT staging (reWriteBatchedInserts 활용) → UPDATE game JOIN staging → TRUNCATE staging. 배치 시작 전 HNSW 인덱스 DROP, 완료 후 재생성하여 인덱스 재조정 오버헤드 제거
- `Session.doWork()`는 raw JDBC를 사용하므로 Hibernate 자동 flush가 일어나지 않음. 메서드 시작 시 `entityManager.flush()`를 명시 호출하여 pending INSERT/UPDATE를 DB에 반영한 뒤 JDBC batch 실행