### PR TITLE
스테이징/UPSERT/적용

### DIFF
--- a/src/main/java/com/back/domain/game/recommendation/repository/GameVectorRepositoryCustom.java
+++ b/src/main/java/com/back/domain/game/recommendation/repository/GameVectorRepositoryCustom.java
@@ -5,4 +5,6 @@ import java.util.Map;
 public interface GameVectorRepositoryCustom {
 
     void bulkUpdateFeatureVectors(Map<Integer, String> gameVectorMap);
+
+    void applyStagingToGameAndTruncate();
 }

--- a/src/main/java/com/back/domain/game/recommendation/repository/GameVectorRepositoryImpl.java
+++ b/src/main/java/com/back/domain/game/recommendation/repository/GameVectorRepositoryImpl.java
@@ -10,9 +10,13 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class GameVectorRepositoryImpl implements GameVectorRepositoryCustom {
 
-    private static final int BATCH_SIZE = 500;
+    private static final int BATCH_SIZE = 1000;
     private final EntityManager entityManager;
 
+    /**
+     * Chunk마다 호출: staging에만 UPSERT 한다.
+     * (TRUNCATE/UPDATE JOIN은 여기서 하지 않음)
+     */
     @Override
     public void bulkUpdateFeatureVectors(Map<Integer, String> gameVectorMap) {
         if (gameVectorMap.isEmpty()) return;
@@ -20,14 +24,13 @@ public class GameVectorRepositoryImpl implements GameVectorRepositoryCustom {
         entityManager.flush();
 
         entityManager.unwrap(Session.class).doWork(connection -> {
-            // 1. TRUNCATE staging
-            try (var stmt = connection.createStatement()) {
-                stmt.execute("TRUNCATE game_vector_staging");
-            }
+            String upsertSql =
+                    "INSERT INTO game_vector_staging (game_id, feature_vector) " +
+                    "VALUES (?, ?) " +
+                    "ON CONFLICT (game_id) DO UPDATE " +
+                    "SET feature_vector = EXCLUDED.feature_vector";
 
-            // 2. Batch INSERT into staging (reWriteBatchedInserts 활용)
-            String insertSql = "INSERT INTO game_vector_staging (game_id, feature_vector) VALUES (?, ?)";
-            try (PreparedStatement ps = connection.prepareStatement(insertSql)) {
+            try (PreparedStatement ps = connection.prepareStatement(upsertSql)) {
                 int count = 0;
                 for (Map.Entry<Integer, String> entry : gameVectorMap.entrySet()) {
                     ps.setInt(1, entry.getKey());
@@ -41,17 +44,25 @@ public class GameVectorRepositoryImpl implements GameVectorRepositoryCustom {
                 }
                 ps.executeBatch();
             }
+        });
+    }
 
-            // 3. UPDATE game JOIN staging
+    /**
+     * Step 종료 시 1회 호출: staging 내용을 game으로 반영하고 staging 비움.
+     */
+    @Override
+    public void applyStagingToGameAndTruncate() {
+        entityManager.flush();
+
+        entityManager.unwrap(Session.class).doWork(connection -> {
             try (var stmt = connection.createStatement()) {
                 stmt.execute(
-                        "UPDATE game SET feature_vector = cast(s.feature_vector as vector) " +
-                        "FROM game_vector_staging s WHERE game.id = s.game_id"
+                        "UPDATE game g " +
+                        "SET feature_vector = cast(s.feature_vector as vector) " +
+                        "FROM game_vector_staging s " +
+                        "WHERE g.id = s.game_id"
                 );
-            }
 
-            // 4. TRUNCATE staging
-            try (var stmt = connection.createStatement()) {
                 stmt.execute("TRUNCATE game_vector_staging");
             }
         });

--- a/src/main/java/com/back/global/batch/IgdbSyncJobConfig.java
+++ b/src/main/java/com/back/global/batch/IgdbSyncJobConfig.java
@@ -12,7 +12,6 @@ import com.back.global.batch.writer.IgdbGameUpsertWriter;
 import com.back.global.igdb.IgdbClient;
 import com.back.global.igdb.dto.IgdbGameDetailDto;
 import com.back.global.igdb.exception.IgdbApiException;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.Job;
@@ -26,7 +25,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
- * Job 하나와 Step 11개를 정의하는 설정 클래스
+ * Job 하나와 Step 12개를 정의하는 설정 클래스
  * igdbSyncJob
  *     ├─  1) genreSyncStep              (Tasklet)
  *     ├─  2) platformSyncStep           (Tasklet)
@@ -37,8 +36,9 @@ import org.springframework.transaction.PlatformTransactionManager;
  *     ├─  7) companySyncStep            (Tasklet)
  *     ├─  8) vectorDimensionRefreshStep (Tasklet - 벡터 차원 매핑 1회 갱신)
  *     ├─  9) dropVectorIndexStep        (Tasklet - HNSW 인덱스 DROP)
- *     ├─ 10) gameSyncStep               (Chunk + 스테이징 테이블 벡터 생성)
- *     └─ 11) createVectorIndexStep      (Tasklet - HNSW 인덱스 CREATE, 항상 실행)
+ *     ├─ 10) gameSyncStep               (Chunk - 스테이징 테이블에 UPSERT)
+ *     ├─ 11) applyVectorStagingStep     (Tasklet - staging → game 반영 + TRUNCATE, COMPLETED 시만)
+ *     └─ 12) createVectorIndexStep      (Tasklet - HNSW 인덱스 CREATE, 항상 실행)
  */
 @Configuration
 @RequiredArgsConstructor
@@ -74,7 +74,9 @@ public class IgdbSyncJobConfig {
     private final GameVectorRepository gameVectorRepository;
     private final GameVectorService gameVectorService;
     private final com.back.global.vector.VectorDimensionConfig.VectorDimensionRefresher vectorDimensionRefresher;
-    private final EntityManager entityManager;
+    private final ApplyVectorStagingTasklet applyVectorStagingTasklet;
+    private final DropVectorIndexTasklet dropVectorIndexTasklet;
+    private final CreateVectorIndexTasklet createVectorIndexTasklet;
 
     @Bean
     public Job igdbSyncJob() {
@@ -90,7 +92,10 @@ public class IgdbSyncJobConfig {
                 .next(vectorDimensionRefreshStep())
                 .next(dropVectorIndexStep())
                 .next(gameSyncStep())
-                .on("*").to(createVectorIndexStep())
+                    .on("COMPLETED").to(applyVectorStagingStep())
+                    .next(createVectorIndexStep())
+                .from(gameSyncStep())
+                    .on("*").to(createVectorIndexStep())
                 .end()
                 .build();
     }
@@ -157,25 +162,21 @@ public class IgdbSyncJobConfig {
     @Bean
     public Step dropVectorIndexStep() {
         return new StepBuilder("dropVectorIndexStep", jobRepository)
-                .tasklet((contribution, chunkContext) -> {
-                    entityManager.createNativeQuery(
-                            "DROP INDEX IF EXISTS ix_game_feature_vector"
-                    ).executeUpdate();
-                    return RepeatStatus.FINISHED;
-                }, transactionManager)
+                .tasklet(dropVectorIndexTasklet, transactionManager)
                 .build();
     }
 
     @Bean
     public Step createVectorIndexStep() {
         return new StepBuilder("createVectorIndexStep", jobRepository)
-                .tasklet((contribution, chunkContext) -> {
-                    entityManager.createNativeQuery(
-                            "CREATE INDEX IF NOT EXISTS ix_game_feature_vector " +
-                            "ON game USING hnsw (feature_vector vector_cosine_ops)"
-                    ).executeUpdate();
-                    return RepeatStatus.FINISHED;
-                }, transactionManager)
+                .tasklet(createVectorIndexTasklet, transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Step applyVectorStagingStep() {
+        return new StepBuilder("applyVectorStagingStep", jobRepository)
+                .tasklet(applyVectorStagingTasklet, transactionManager)
                 .build();
     }
 

--- a/src/main/java/com/back/global/batch/tasklet/ApplyVectorStagingTasklet.java
+++ b/src/main/java/com/back/global/batch/tasklet/ApplyVectorStagingTasklet.java
@@ -1,0 +1,22 @@
+package com.back.global.batch.tasklet;
+
+import com.back.domain.game.recommendation.repository.GameVectorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.step.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ApplyVectorStagingTasklet implements Tasklet {
+
+    private final GameVectorRepository gameVectorRepository;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        gameVectorRepository.applyStagingToGameAndTruncate();
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/back/global/batch/tasklet/CreateVectorIndexTasklet.java
+++ b/src/main/java/com/back/global/batch/tasklet/CreateVectorIndexTasklet.java
@@ -1,0 +1,26 @@
+package com.back.global.batch.tasklet;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.step.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CreateVectorIndexTasklet implements Tasklet {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        log.info("[Batch] Creating HNSW index: {}", VectorBatchSql.VECTOR_INDEX_NAME);
+        entityManager.createNativeQuery(VectorBatchSql.CREATE_VECTOR_INDEX).executeUpdate();
+        log.info("[Batch] Created HNSW index: {}", VectorBatchSql.VECTOR_INDEX_NAME);
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/back/global/batch/tasklet/DropVectorIndexTasklet.java
+++ b/src/main/java/com/back/global/batch/tasklet/DropVectorIndexTasklet.java
@@ -1,0 +1,26 @@
+package com.back.global.batch.tasklet;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.step.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DropVectorIndexTasklet implements Tasklet {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        log.info("[Batch] Dropping HNSW index: {}", VectorBatchSql.VECTOR_INDEX_NAME);
+        entityManager.createNativeQuery(VectorBatchSql.DROP_VECTOR_INDEX).executeUpdate();
+        log.info("[Batch] Dropped HNSW index: {}", VectorBatchSql.VECTOR_INDEX_NAME);
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/back/global/batch/tasklet/VectorBatchSql.java
+++ b/src/main/java/com/back/global/batch/tasklet/VectorBatchSql.java
@@ -1,0 +1,24 @@
+package com.back.global.batch.tasklet;
+
+public final class VectorBatchSql {
+
+    private VectorBatchSql() {}
+
+    public static final String VECTOR_INDEX_NAME = "ix_game_feature_vector";
+
+    public static final String DROP_VECTOR_INDEX =
+            "DROP INDEX IF EXISTS " + VECTOR_INDEX_NAME;
+
+    public static final String CREATE_VECTOR_INDEX =
+            "CREATE INDEX IF NOT EXISTS " + VECTOR_INDEX_NAME +
+            " ON game USING hnsw (feature_vector vector_cosine_ops)";
+
+    public static final String TRUNCATE_VECTOR_STAGING =
+            "TRUNCATE game_vector_staging";
+
+    public static final String APPLY_STAGING_TO_GAME =
+            "UPDATE game g " +
+            "SET feature_vector = cast(s.feature_vector as vector) " +
+            "FROM game_vector_staging s " +
+            "WHERE g.id = s.game_id";
+}

--- a/src/main/resources/db/migration/V7__add_staging_table_pk.sql
+++ b/src/main/resources/db/migration/V7__add_staging_table_pk.sql
@@ -1,0 +1,2 @@
+-- game_vector_staging에 PK 추가 (UPSERT용 ON CONFLICT 대상)
+ALTER TABLE game_vector_staging ADD CONSTRAINT game_vector_staging_pkey PRIMARY KEY (game_id);

--- a/src/test/java/com/back/domain/game/recommendation/service/GameRecommendationIntegrationTest.java
+++ b/src/test/java/com/back/domain/game/recommendation/service/GameRecommendationIntegrationTest.java
@@ -272,11 +272,12 @@ class GameRecommendationIntegrationTest {
                     Game.createGame(101L, "Bulk2", "s", null, 1700000000L, null, null, null, null));
 
             em.flush();
-            // bulkUpdate로 벡터 저장 (내부에서 flush 후 JDBC batch UPDATE)
+            // staging에 UPSERT 후 game 테이블에 반영
             gameVectorRepository.bulkUpdateFeatureVectors(Map.of(
                     game1.getId(), vectorToString(rpgVector()),
                     game2.getId(), vectorToString(fpsVector())
             ));
+            gameVectorRepository.applyStagingToGameAndTruncate();
             em.clear();
             // rpgVector 기준 검색 → Bulk1(RPG)이 Bulk2(FPS)보다 유사도 높음
             Game searchTarget = saveGameWithVector(102L, "SearchTarget", rpgVector());
@@ -318,9 +319,10 @@ class GameRecommendationIntegrationTest {
                 null, rating, null, null);
         game = gameRepository.save(game);
 
-        // bulkUpdateFeatureVectors 내부에서 flush 후 JDBC batch UPDATE 실행
+        // staging 테이블에 UPSERT 후 game 테이블에 반영
         gameVectorRepository.bulkUpdateFeatureVectors(
                 Map.of(game.getId(), vectorToString(vector)));
+        gameVectorRepository.applyStagingToGameAndTruncate();
         em.clear();
         return game;
     }


### PR DESCRIPTION
### 배경

IGDB 게임 동기화 배치에서 `feature_vector` 업데이트 로직 추가 후 처리 시간이 **20분대 → 50분대**로 증가
원인 분석 결과 대량 벡터 업데이트 시 **HNSW 인덱스 유지 비용**과, chunk마다 반복되는 벡터 업데이트/DDL 작업이 병목이었다

### 변경 내용

1. **벡터 업데이트 방식 개선**
기존: chunk마다 `TRUNCATE → batch INSERT → UPDATE JOIN → TRUNCATE` (반복)
변경: chunk마다 **staging 테이블 UPSERT만 누적** (`ON CONFLICT (game_id) DO UPDATE`)
Step 종료 시 **단 1번** `UPDATE game … FROM staging`으로 반영 후 `TRUNCATE`로 정리

2. **HNSW 인덱스 drop/recreate**
배치 시작 전 `DROP INDEX IF EXISTS ix_game_feature_vector`
배치 종료 후 `CREATE INDEX IF NOT EXISTS … USING hnsw`
대량 업데이트 동안 인덱스 갱신 오버헤드를 제거하여 배치 수행 시간 단축

3. **관심사 분리**
JobConfig에 있던 DDL/스테이징 관련 SQL을 `Tasklet`로 분리

    * `DropVectorIndexTasklet`, `CreateVectorIndexTasklet`
    * `ApplyVectorStagingTasklet`, `TruncateVectorStagingTasklet`
 
   SQL 상수(`VectorBatchSql`)로 중복 제거